### PR TITLE
fix fluid resistance plugin drag force formula

### DIFF
--- a/src/physics_plugins/fluid_resistance_plugin.cpp
+++ b/src/physics_plugins/fluid_resistance_plugin.cpp
@@ -252,9 +252,9 @@ void FluidResistancePlugin::ApplyResistance() {
   math::Vector3 force, torque;
 #endif
 
-  force.X(-1.0 * (res_x * model_mass) * now_lin_vel.X());
-  force.Y(-1.0 * (res_y * model_mass) * now_lin_vel.Y());
-  force.Z(-1.0 * (res_z * model_mass) * now_lin_vel.Z());
+  force.X(-1.0 * res_x * now_lin_vel.X());
+  force.Y(-1.0 * res_y * now_lin_vel.Y());
+  force.Z(-1.0 * res_z * now_lin_vel.Z());
 
   // Applying force to uav
   link_to_apply_resistance->AddRelativeForce(force);


### PR DESCRIPTION
This pull request makes a targeted adjustment to the calculation of fluid resistance forces in the `FluidResistancePlugin`. The change removes the multiplication by `model_mass` from the resistance force calculation, ensuring that the resistance coefficients (`res_x`, `res_y`, `res_z`) are applied directly to the velocity components.

Physics calculation correction:

* Updated the force calculation in `FluidResistancePlugin::ApplyResistance()` (in `fluid_resistance_plugin.cpp`) to remove the unnecessary multiplication by `model_mass`, so resistance is now proportional only to the velocity and resistance coefficients.