### PR TITLE
fix: update Multicopter plugin export destination

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ ament_target_dependencies(MrsGazeboCommonResources_MulticopterMotorModel
 
 install(
   TARGETS MrsGazeboCommonResources_MulticopterMotorModel
-  LIBRARY DESTINATION lib/${PROJECT_NAME}
+  LIBRARY DESTINATION lib
 )
 
 ament_export_dependencies(


### PR DESCRIPTION
Adding a dependency on this package will cause a compilation error because of the nested target destination. Un-nesting resolves the issue. 